### PR TITLE
Adding goreleaser bin from goreleaser/goreleaser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.10-alpine
 
-MAINTAINER Tom Manville<tom@kasten.io>
+LABEL maintainer Tom Manville<tom@kasten.io>
 
 RUN apk add --update --no-cache \
         ca-certificates \
@@ -15,7 +15,7 @@ RUN apk add --update --no-cache \
  # Install kubectl
  && curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
  && chmod +x kubectl \
- && mv kubectl /bin/kubectl \ 
+ && mv kubectl /bin/kubectl \
  # Download and unpack Glide sources
  && curl -L -o /tmp/glide.tar.gz \
           https://github.com/Masterminds/glide/archive/v0.13.1.tar.gz \
@@ -35,3 +35,4 @@ RUN apk add --update --no-cache \
            $GOPATH/src/* \
            /tmp/*
 
+COPY --from=goreleaser/goreleaser /goreleaser /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN apk add --update --no-cache \
            $GOPATH/src/* \
            /tmp/*
 
-COPY --from=goreleaser/goreleaser /goreleaser /usr/local/bin/
+COPY --from=goreleaser/goreleaser:v0.75 /goreleaser /usr/local/bin/


### PR DESCRIPTION
modifying Maintainer field

testing:
```
make
docker build --network=host  \
        -t kanisterio/build:0.13.1-go1.10 .
Sending build context to Docker daemon  4.096kB
Step 1/4 : FROM golang:1.10-alpine
 ---> 05fe62871090
Step 2/4 : LABEL maintainer Tom Manville<tom@kasten.io>
 
Step 4/4 : COPY --from=goreleaser/goreleaser /goreleaser /usr/local/bin/
 ---> Using cache
 ---> dbaddeab0d5f
Successfully built dbaddeab0d5f
Successfully tagged kanisterio/build:0.13.1-go1.10
```

```
docker run -ti --rm kanisterio/build:0.13.1-go1.10 goreleaser --version

0.74.0, commit 08c4f468436b276184b017f0df16cf2dc9be6df9, built at 2018-05-13T20:30:10Z
```