### PR TITLE
Upgrade Glide to v0.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --update --no-cache \
  && mv kubectl /bin/kubectl \
  # Download and unpack Glide sources
  && curl -L -o /tmp/glide.tar.gz \
-          https://github.com/Masterminds/glide/archive/v0.13.1.tar.gz \
+          https://github.com/Masterminds/glide/archive/v0.13.2.tar.gz \
  && tar -xzf /tmp/glide.tar.gz -C /tmp \
  && mkdir -p $GOPATH/src/github.com/Masterminds \
  && mv /tmp/glide-* $GOPATH/src/github.com/Masterminds/glide \


### PR DESCRIPTION
Glide 0.13.2 update fixes the segfault problem in Kanister build. 

* Upgrade Glide to v0.13.2
